### PR TITLE
FIX - MICROTIMECONVERTER

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A helper function to convert microtime to hours/minutes/seconds/milliseconds.",
   "type": "library",
   "require": {
-    "php": "^7.0"
+    "php": "^5.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
* change composer
* works perfect into php 5.6
* removing unnecessary barrier or use